### PR TITLE
Convert DbContextFactory into a dynamic and model-independent generator

### DIFF
--- a/ExamTestAPI.Repositories/Context/DbContextFactory.cs
+++ b/ExamTestAPI.Repositories/Context/DbContextFactory.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,15 +7,15 @@ using System.Threading.Tasks;
 
 namespace ExamTestAPI.Repositories.Context
 {
-    public static class EmployeeDbContextFactory
+    public static class DbContextFactory
     {
-        public static EmployeeDbContext Create(string dataBaseName)
+        public static T Create<T>(string dataBaseName) where T : DbContext
         {
-            var options = new DbContextOptionsBuilder<EmployeeDbContext>()
+            var options = new DbContextOptionsBuilder<T>()
                 .UseInMemoryDatabase(dataBaseName)
                 .Options;
 
-            var context = new EmployeeDbContext(options);
+            var context = (T)Activator.CreateInstance(typeof(T), options);
 
             context.Database.EnsureCreated();
 

--- a/ExamTestAPI/Program.cs
+++ b/ExamTestAPI/Program.cs
@@ -20,7 +20,7 @@ namespace ExamTestAPI
             builder.Services.AddSwaggerGen();
 
             //Dependeces injections
-            builder.Services.AddSingleton<EmployeeDbContext>(EmployeeDbContextFactory.Create("EmployeeDb"));
+            builder.Services.AddSingleton<EmployeeDbContext>(DbContextFactory.Create<EmployeeDbContext>("EmployeeDb"));
             builder.Services.AddTransient<IEmployeeRepository, EmployeeRepository>();
             builder.Services.AddTransient<IEmployeeService, EmployeeService>();
 


### PR DESCRIPTION
Fixes #3

This PR modify the EmployeeDbContextFactory to create a new dynamic DbContextFactory  

Rename `EmployeeDbContextFactory` to `DbContextFactory` and make it generic.

* Rename file `ExamTestAPI.Repositories/Context/EmployeeDbContextFactory.cs` to `ExamTestAPI.Repositories/Context/DbContextFactory.cs`
* Change `Create` method to be generic and accept any `DbContext` type
* Use `public static T Create<T>(string dataBaseName) where T : DbContext`
* Ensure the method returns an instance of the corresponding `DbContext`
* Update dependency injection in `ExamTestAPI/Program.cs` to use the new `DbContextFactory`
* Replace `EmployeeDbContextFactory.Create` with `DbContextFactory.Create<EmployeeDbContext>`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LuigimonSoft/TestTecniqueDotNet/pull/4?shareId=9a814669-f385-45ad-9e30-7ef409a7fcdc).